### PR TITLE
Support for conduit-combinators-1.0.0

### DIFF
--- a/test/find-hs.hs
+++ b/test/find-hs.hs
@@ -1,3 +1,5 @@
+{-#LANGUAGE CPP#-}
+
 module Main where
 
 import Conduit
@@ -16,10 +18,15 @@ main = do
         "conduit" -> do
             putStrLn "Running sourceDirectoryDeep from conduit-extra"
             runResourceT $
-                sourceDirectoryDeep False (decodeString dir)
+#if MIN_VERSION_conduit_combinators(1,0,0)
+              sourceDirectoryDeep False dir
+                    =$ filterC (".hs" `isSuffixOf`)
+                    $$ mapM_C (liftIO . putStrLn)
+#else
+              sourceDirectoryDeep False (decodeString dir)
                     =$ filterC ((".hs" `isSuffixOf`) . encodeString)
                     $$ mapM_C (liftIO . putStrLn . encodeString)
-
+#endif
         "find-conduit" -> do
             putStrLn "Running findFiles from find-conduit"
             findFiles defaultFindOptions { findFollowSymlinks = False }


### PR DESCRIPTION
When  conduit-combinators-1.0.0 is used, build fails.
FilePath of conduit-combinators is changed from system-filepath to base(System.IO) .
This patch supports both old conduit-combinators and new one.
