### PR TITLE
Preliminary support for ghc-9.14

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250531
+# version: 0.19.20250605
 #
-# REGENDATA ("0.19.20250531",["github","cabal.project"])
+# REGENDATA ("0.19.20250605",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -28,19 +28,24 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.10.1
+          - compiler: ghc-9.12.1
             compilerKind: ghc
-            compilerVersion: 9.10.1
+            compilerVersion: 9.12.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.8.2
+          - compiler: ghc-9.10.2
             compilerKind: ghc
-            compilerVersion: 9.8.2
+            compilerVersion: 9.10.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.6.5
+          - compiler: ghc-9.8.4
             compilerKind: ghc
-            compilerVersion: 9.6.5
+            compilerVersion: 9.8.4
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.6.7
+            compilerKind: ghc
+            compilerVersion: 9.6.7
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.8

--- a/cabal.project
+++ b/cabal.project
@@ -3,3 +3,38 @@ packages:
 
 tests: True
 test-show-details: direct
+
+if impl (ghc >= 9.14)
+  allow-newer:
+    , async:base
+
+-- cabal-allow-newer
+if impl (ghc >= 9.14)
+  allow-newer:
+    , bifunctors:template-haskell
+    , comonad:indexed-traversable
+    , directory:base
+    , hashable:base
+    , hashable:bytestring
+    , hashable:ghc-bignum
+    , hsc2hs:base
+    , indexed-traversable:base
+    , integer-logarithms:base
+    , integer-logarithms:ghc-bignum
+    , primitive:base
+    , random:splitmix
+    , scientific:base
+    , scientific:containers
+    , semigroupoids:bifunctors
+    , semigroupoids:hashable
+    , splitmix:base
+    , tagged:template-haskell
+    , text:bytestring
+    , text:template-haskell
+    -- th-abstraction is broken for ghc-9.14
+    , th-abstraction:template-haskell
+    , transformers:base
+    , unix:base
+    , unordered-containers:base
+    , unordered-containers:hashable
+    , unordered-containers:template-haskell

--- a/conduit-find.cabal
+++ b/conduit-find.cabal
@@ -47,7 +47,7 @@ Library
       , conduit-combinators
       , attoparsec
       , unix-compat          >= 0.4.1.1
-      , text                 >= 2.0 && < 2.2
+      , text                 >= 1.2 && < 2.2
       , regex-posix
       , mtl
       , semigroups
@@ -79,7 +79,7 @@ test-suite test
       , conduit-combinators
       , attoparsec
       , unix-compat
-      , text                 >= 2.0 && < 2.2
+      , text
       , regex-posix
       , mtl
       , time
@@ -121,7 +121,7 @@ Executable find-hs
       , conduit-combinators
       , attoparsec
       , unix
-      , text                 >= 2.0 && < 2.2
+      , text
       , regex-posix
       , mtl
       , time


### PR DESCRIPTION
Currently using ghc-9.14.0.20250819.

One of the dependencies, `th-abstractions` does not build.